### PR TITLE
Fixing wrong variable in sample code

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,9 +88,9 @@ SmsAndroid.list(JSON.stringify(filter), (fail) => {
         var arr = JSON.parse(smsList);
 
         arr.forEach(function(object){
-            console.log("Object: " + obj);
-            console.log("-->" + obj.date);
-            console.log("-->" + obj.body);
+            console.log("Object: " + object);
+            console.log("-->" + object.date);
+            console.log("-->" + object.body);
         })
     });
 


### PR DESCRIPTION
This pull request fixes the **Can't find variable obj** in sample code given. Variable 'object' is used in function parameters, but while printing the object to console instead of using 'object' variable 'obj ' name being used. This is causing the Can't find variable obj issue. 
The fix is given by renaming the variable name to 'object'