### PR TITLE
Point parent dependency to main repo

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "react": "16.6.3",
     "react-native": "0.58.6",
-    "react-native-get-sms-android": "github:mikehardy/react-native-get-sms-android"
+    "react-native-get-sms-android": "github:briankabiro/react-native-get-sms-android"
   },
   "devDependencies": {
     "babel-core": "^7.0.0-bridge.0",


### PR DESCRIPTION
Update the dependency on the parent module (which we are attempting to demonstrate) to the main repo instead of my repo, an oversight from #26