### PR TITLE
missing : in settings.gradle for linking

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ The package allows you to:
 _android/settings.gradle_
 
     include ':react-native-get-sms-android'
-    project('react-native-get-sms-android').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-get-sms-android/android')
+    project(':react-native-get-sms-android').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-get-sms-android/android')
 
 _android/app/build.gradle_
 


### PR DESCRIPTION
There is a missing `:` in settings.gradle manual setup, which gives 
`> Project with path 'react-native-get-sms-android' could not be found.` this error. 