### PR TITLE
Revert regression in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,12 +88,24 @@ import SmsAndroid from 'react-native-get-sms-android';
 /* List SMS messages matching the filter */
 var filter = {
   box: 'inbox', // 'inbox' (default), 'sent', 'draft', 'outbox', 'failed', 'queued', and '' for all
-  // the next 4 filters should NOT be used together, they are OR-ed so pick one
+
+  /**
+   *  the next 2 filters work like this:
+   *    - If and only if you set a maxDate, it's like executing this SQL query:
+   *    "SELECT * from messages WHERE (other filters) AND date <= maxDate"
+   *    - Same for minDate but with "date >= minDate"
+   */
+  minDate: 1554636310165, // timestamp (in milliseconds since UNIX epoch)
+  maxDate: 1556277910456, // timestamp (in milliseconds since UNIX epoch)
+
+  /** the next 5 filters should NOT be used together, they are OR-ed so pick one **/
   read: 0, // 0 for unread SMS, 1 for SMS already read
   _id: 1234, // specify the msg id
+  thread_id: 12 // specify the conversation thread_id
   address: '+1888------', // sender's phone number
   body: 'How are you', // content to match
-  // the next 2 filters can be used for pagination
+
+  /** the next 2 filters can be used for pagination **/
   indexFrom: 0, // start from index 0
   maxCount: 10, // count of SMS to return each time
 };


### PR DESCRIPTION
I think that this commit (https://github.com/briankabiro/react-native-get-sms-android/commit/3870f40a8b734a759139cc3389367f35398fa63e#diff-04c6e90faac2675aa89e2176d2eec7d8) mistakenly removed some parts of the documentation about features that are still available. I only checked the "filters" section so I might be missing some other regression.