### PR TITLE
Replace 0 by PendingIntent.FLAG_IMMUTABLE for Android>12 comptatibility

### DIFF
--- a/android/src/main/java/com/react/SmsModule.java
+++ b/android/src/main/java/com/react/SmsModule.java
@@ -168,7 +168,7 @@ public class SmsModule extends ReactContextBaseJavaModule /*implements LoaderMan
             JSONArray addressList = jsonObject.getJSONArray("addressList");
             int n;
             if ((n = addressList.length()) > 0) {
-                PendingIntent sentIntent = PendingIntent.getBroadcast(mActivity, 0, new Intent("SENDING_SMS"), 0);
+                PendingIntent sentIntent = PendingIntent.getBroadcast(mActivity, 0, new Intent("SENDING_SMS"), PendingIntent.FLAG_IMMUTABLE);
                 SmsManager sms = SmsManager.getDefault();
                 for (int i = 0; i < n; i++) {
                     String address;
@@ -176,7 +176,7 @@ public class SmsModule extends ReactContextBaseJavaModule /*implements LoaderMan
                         sms.sendTextMessage(address, null, text, sentIntent, null);
                 }
             } else {
-                PendingIntent sentIntent = PendingIntent.getActivity(mActivity, 0, new Intent("android.intent.action.VIEW"), 0);
+                PendingIntent sentIntent = PendingIntent.getActivity(mActivity, 0, new Intent("android.intent.action.VIEW"), PendingIntent.FLAG_IMMUTABLE);
                 Intent intent = new Intent("android.intent.action.VIEW");
                 intent.putExtra("sms_body", text);
                 intent.setData(Uri.parse("sms:"));
@@ -241,8 +241,8 @@ public class SmsModule extends ReactContextBaseJavaModule /*implements LoaderMan
             ArrayList<PendingIntent> sentPendingIntents = new ArrayList<PendingIntent>();
             ArrayList<PendingIntent> deliveredPendingIntents = new ArrayList<PendingIntent>();
 
-            PendingIntent sentPI = PendingIntent.getBroadcast(context, 0, new Intent(SENT), 0);
-            PendingIntent deliveredPI = PendingIntent.getBroadcast(context, 0, new Intent(DELIVERED), 0);
+            PendingIntent sentPI = PendingIntent.getBroadcast(context, 0, new Intent(SENT), PendingIntent.FLAG_IMMUTABLE);
+            PendingIntent deliveredPI = PendingIntent.getBroadcast(context, 0, new Intent(DELIVERED), PendingIntent.FLAG_IMMUTABLE);
 
             //---when the SMS has been sent---
             context.registerReceiver(new BroadcastReceiver() {


### PR DESCRIPTION
This pull request addresses the requirement of specifying either `FLAG_IMMUTABLE` or `FLAG_MUTABLE` when creating `PendingIntent` instances on Android 12 (API level 31) and higher, as per Android 12 behavior changes.

I edited the source code to replace `0` by `FLAG_IMMUTABLE` when creating new instances of `PendingIntent`. In our case, we don't need the `PendingIntent` to be mutable. That's why I used `FLAG_IMMUTABLE`.

Thanks to those changes, the library can be used again on latest versions of Android and we avoid having the following error when using the library's methods :

```
Targeting S+ (version 31 and above) requires that one of FLAG_IMMUTABLE or FLAG_MUTABLE
```

For more information: check the [StackOverflow post explaining the issue and its fix](https://stackoverflow.com/a/74850656/16661695).